### PR TITLE
Improve markdown styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5727,15 +5727,6 @@
         "import-cwd": "^2.0.0"
       }
     },
-    "postcss-logical": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-4.0.2.tgz",
-      "integrity": "sha512-tlX1n19np6/JznvyymZM6SIe0FymD5Ngwcg2j825vNKhADu0p1PTgEmsCjakCbvn78kaIFzYTI32NpgOEwgifQ==",
-      "dev": true,
-      "requires": {
-        "postcss": "^7.0.17"
-      }
-    },
     "postcss-merge-longhand": {
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "postcss-each": "^0.10.0",
     "postcss-extend": "^1.0.5",
     "postcss-import": "^12.0.1",
-    "postcss-logical": "^4.0.2",
     "postcss-nesting": "^7.0.1",
     "rollup": "^2.6.1",
     "rollup-plugin-node-builtins": "^2.1.2",

--- a/site/_includes/assets/postcss-css/base.css
+++ b/site/_includes/assets/postcss-css/base.css
@@ -96,3 +96,24 @@ code {
   color: var(--inline-code-color);
   font-style: italic;
 }
+
+.markdown {
+  & h1 {
+    margin-block-end: var(--space-12);
+  }
+  & h2,
+  & h3,
+  & h4,
+  & h5,
+  & h6 {
+    & + p,
+    & + span,
+    & + pre {
+      margin-block-start: var(--space-1);
+    }
+  }
+  & p,
+  & pre {
+    margin-block-end: var(--space-8);
+  }
+}

--- a/site/_includes/layout.njk
+++ b/site/_includes/layout.njk
@@ -4,7 +4,7 @@ includeNewsletterForm: true
 description: "Web Dev, Accessibility Specialist, Doing My Best to Make the Web Inclusive"
 ---
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -86,7 +86,7 @@ description: "Web Dev, Accessibility Specialist, Doing My Best to Make the Web I
                 &copy;
                 {{siteMetadata.owner}} &mdash; {{siteMetadata.year}}
             </span>
-            <ul class="flex flex-shrink justify-center">
+            <ul class="flex flex-shrink justify-center" role="list">
                 {% for socialMediaSite in siteMetadata.socialMedia %}
                 <li class="mr-4 h-6 w-6">
                     <a href="{{socialMediaSite.url}}" aria-label="Darrik's {{socialMediaSite.name}}">

--- a/site/writing/index.html
+++ b/site/writing/index.html
@@ -9,18 +9,20 @@ isMarkdown: true
     {%- for post in collections.writing reversed -%}
     <li>
         <article class="block">
-            <h3><a href="{{post.url | url}}" class=" inline-block mb-2">{{post.data.title}}</a></h3>    
+            <h2 class="text-xl"><a href="{{post.url | url}}" class="inline-block mb-2">{{post.data.title}}</a></h2>
             {{post.data.description}}
         </article>
     </li>
     {%- endfor -%}
 </ul>
 <section class="topic-section">
-<h2 id="topic-header" class="font-semibold md:text-2xl text-xl mb-2">Find Articles By Topic</h2>
-{%-assign tags = collections | keys | excludeValue: "all" | excludeValue: "writing" | excludeValue: "notes" | sortAlphabetical  -%}
-<ul aria-labelledby="topic-header">
-{%- for tag in tags-%}
-<li><a href="/{{tag | replace: " ", "-" | urlencode}}" class="text-regular md:text-xl">{{tag | capitalize}}</a></li>
-{%- endfor -%}
-</ul>
+    <h2 id="topic-header" class="font-semibold md:text-2xl text-xl mb-2">Find Articles By Topic</h2>
+    {%-assign tags = collections | keys | excludeValue: "all" | excludeValue: "writing" | excludeValue: "notes" |
+    sortAlphabetical -%}
+    <ul aria-labelledby="topic-header">
+        {%- for tag in tags-%}
+        <li><a href="/{{tag | replace: " ", " -" | urlencode}}" class="text-regular md:text-xl">{{tag | capitalize}}</a>
+        </li>
+        {%- endfor -%}
+    </ul>
 </section>

--- a/utils/postCss-filter.js
+++ b/utils/postCss-filter.js
@@ -9,7 +9,6 @@ const postCssExtend = require("postcss-extend");
 const postCssAtRules = require("postcss-at-rules-variables");
 const autoprefixer = require("autoprefixer");
 const cssNano = require("cssnano");
-const postCssLogical = require("postcss-logical");
 
 const purgeCSS = purgeCssFunction({
   content: [
@@ -32,10 +31,6 @@ module.exports = async function (cssFile) {
     postCssEach(),
     postCssExtend(),
     postCssNesting(),
-    postCssLogical({
-      dir: "ltr",
-      preserve: true,
-    }),
     ...(process.env.NODE_ENV === "production"
       ? [purgeCSS, cssNano({ preset: "default" })]
       : []),


### PR DESCRIPTION
- Improves the styles of markdown-based pages (blog posts!)
- Fixes the header hierarchy on the /writing page to be correct
- Removes postcss-logical because the preserve option fails to work properly and most browsers support it