### PR TITLE
chore: add robots.txt that excludes gpt

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -26,6 +26,7 @@ function getAccentBorderColor(color = "") {
 module.exports = function (eleventyConfig) {
   //passThrough
   eleventyConfig.addPassthroughCopy("site/images");
+  eleventyConfig.addPassthroughCopy("site/robots.txt");
   eleventyConfig.addPassthroughCopy({
     "site/_includes/prism-a11y-dark.css": "prism-a11y-dark.css",
   });

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,0 +1,2 @@
+User-agent: GPTBot
+Disallow: /


### PR DESCRIPTION
# Disallow gptbot from  crawling

Adds a robots.txt file with a signal that GPTbot shouldn't crawl the site. 